### PR TITLE
Usando o Argument Captor e métodos estáticos

### DIFF
--- a/src/main/java/br/com/alura/leilao/service/GeradorDePagamento.java
+++ b/src/main/java/br/com/alura/leilao/service/GeradorDePagamento.java
@@ -1,5 +1,7 @@
 package br.com.alura.leilao.service;
 
+import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +14,30 @@ import br.com.alura.leilao.model.Pagamento;
 @Service
 public class GeradorDePagamento {
 
-	@Autowired
 	private PagamentoDao pagamentos;
+	private Clock clock;
+	
+	@Autowired
+	public GeradorDePagamento(PagamentoDao pagamentos, Clock clock) {
+		this.pagamentos = pagamentos;
+		this.clock = clock;
+	}
 
 	public void gerarPagamento(Lance lanceVencedor) {
-		LocalDate vencimento = LocalDate.now().plusDays(1);
-		Pagamento pagamento = new Pagamento(lanceVencedor, vencimento);
+		LocalDate vencimento = LocalDate.now(clock).plusDays(1);
+		Pagamento pagamento = new Pagamento(lanceVencedor, proximoDiaUtil(vencimento));
 		this.pagamentos.salvar(pagamento);
+	}
+
+	private LocalDate proximoDiaUtil(LocalDate dataBase) {
+		DayOfWeek diaDaSemana = dataBase.getDayOfWeek();
+		if (diaDaSemana == DayOfWeek.SATURDAY) {
+			return dataBase.plusDays(2);
+		} else if (diaDaSemana == DayOfWeek.SUNDAY) {
+			return dataBase.plusDays(1);
+		}
+		
+		return dataBase;
 	}
 
 }

--- a/src/test/java/br/com/alura/leilao/service/GeradorDePagamentoTest.java
+++ b/src/test/java/br/com/alura/leilao/service/GeradorDePagamentoTest.java
@@ -1,0 +1,83 @@
+package br.com.alura.leilao.service;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import br.com.alura.leilao.dao.PagamentoDao;
+import br.com.alura.leilao.model.Lance;
+import br.com.alura.leilao.model.Leilao;
+import br.com.alura.leilao.model.Pagamento;
+import br.com.alura.leilao.model.Usuario;
+
+class GeradorDePagamentoTest {
+	
+	private GeradorDePagamento gerador;
+	
+	@Mock
+	private PagamentoDao pagamentoDao;
+	
+	@Captor
+	private ArgumentCaptor<Pagamento> captor;
+	
+	@Mock
+	private Clock clock;
+	
+	@BeforeEach
+	public void beforeEach() {
+		MockitoAnnotations.initMocks(this);
+		this.gerador = new GeradorDePagamento(pagamentoDao, clock);
+	}
+
+	@Test
+	void deveriaCriarPagamentoParaVencedorDoLeilao() {
+		Leilao leilao = leilao();
+		Lance vencedor = leilao.getLanceVencedor();
+		
+		LocalDate data = LocalDate.of(2020, 12, 7);
+		
+		Instant instant  = data.atStartOfDay(ZoneId.systemDefault()).toInstant();
+		
+		Mockito.when(clock.instant()).thenReturn(instant);
+		Mockito.when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+		
+		gerador.gerarPagamento(vencedor);
+		
+		Mockito.verify(pagamentoDao).salvar(captor.capture());
+		
+		Pagamento pagamento = captor.getValue();
+		
+		Assert.assertEquals(LocalDate.now().plusDays(1), 
+				pagamento.getVencimento());
+		Assert.assertEquals(vencedor.getValor(), pagamento.getValor());
+		Assert.assertFalse(pagamento.getPago());
+		Assert.assertEquals(vencedor.getUsuario(), pagamento.getUsuario());
+		Assert.assertEquals(leilao, pagamento.getLeilao());
+	}
+	
+	private Leilao leilao() {
+		Leilao leilao = new Leilao("Celular", 
+				new BigDecimal("500"), 
+				new Usuario("Fulano"));
+		
+		Lance lance = new Lance(new Usuario("Ciclano"), 
+				new BigDecimal("900"));
+		
+		leilao.propoe(lance);
+		leilao.setLanceVencedor(lance);
+		
+		return leilao;
+	}
+
+}


### PR DESCRIPTION
Nesta aula consegui aprender como utilizar o recurso de `Argument Captor` do `Mockito` e os problemas de se fazer chamadas a métodos estáticos quando precisamos escrever testes automatizados com a utilização de _mocks_, pensar em abstrações para substituir chamadas a métodos estáticos, como substituir ou criar classes que possam ser passadas como _mocks_, é um meio viável de lidar com esse obstáculo.